### PR TITLE
Add sidebar logo placeholder

### DIFF
--- a/main/static/main/img/logo.svg
+++ b/main/static/main/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80" viewBox="0 0 200 80">
+  <rect width="200" height="80" fill="#f8f9fa" />
+  <text x="100" y="50" font-size="32" text-anchor="middle" fill="#0d6efd" font-family="Arial, sans-serif">Vraa</text>
+</svg>

--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -30,6 +30,13 @@
           class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse"
         >
           <div class="position-sticky pt-3">
+            <div class="text-center mb-4">
+              <img
+                src="{% static 'main/img/logo.svg' %}"
+                alt="Vraa logo"
+                class="img-fluid"
+              />
+            </div>
             <ul class="nav flex-column">
               <li class="nav-item">
                 <a


### PR DESCRIPTION
## Summary
- show a logo at the top of the sidebar navigation
- include a placeholder SVG logo under `static/main/img`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689af45f5bc4832ba0d19554c2d68b84