### PR TITLE
Fix invalid Bootstrap SRI hash in base template

### DIFF
--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -83,7 +83,7 @@
     <!-- Bootstrap JS (optional) -->
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-ENjdO4Dr2bkBIFxQpeoA6vlpJ8lV2C8rj +QEkgm3IU2KqvcqK5P5STJDN7yX1z6"
+      integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
       crossorigin="anonymous"
     ></script>
   </body>

--- a/main/tests.py
+++ b/main/tests.py
@@ -16,3 +16,11 @@ class SimpleTestCase(TestCase):
     def test_frontpage(self) -> None:
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
+
+    def test_bootstrap_integrity_hash(self) -> None:
+        """The base template should include the correct SRI hash for Bootstrap."""
+        response = self.client.get('/')
+        self.assertContains(
+            response,
+            'integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"',
+        )


### PR DESCRIPTION
## Summary
- Correct Bootstrap bundle script's SRI hash in base template
- Add regression test verifying the hash

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689af43ba800832bacc8aa6b81d9c42f