### PR TITLE
Fix main content alignment by closing nav properly

### DIFF
--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -70,7 +70,7 @@
               </li>
             </ul>
           </div>
-        </aside>
+        </nav>
 
         <!-- Main content (centered column) -->
         <main class="col-12 col-md-9 col-lg-10 px-4">


### PR DESCRIPTION
## Summary
- close sidebar navigation element correctly so main content appears beside it

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689b2bb05240832b989214e802a783d5