### PR TITLE
Add frontpage banner image and full-height sidebar

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -1,3 +1,8 @@
+/* Ensure sidebar spans full viewport height */
+.sidebar {
+  min-height: 100vh;
+}
+
 /* Sticky sidebar behavior */
 .sidebar-sticky {
   position: sticky;

--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -23,7 +23,7 @@
           id="sidebarMenu"
           class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse"
         >
-          <div class="position-sticky pt-3">
+          <div class="sidebar-sticky pt-3">
             <div class="text-center mb-4">
               <img
                 src="{% static 'main/img/logo.svg' %}"

--- a/main/templates/main/frontpage.html
+++ b/main/templates/main/frontpage.html
@@ -1,6 +1,11 @@
 {% extends 'main/base.html' %}
 
 {% block content %}
+  <img
+    src="https://picsum.photos/id/1015/1200/400"
+    alt="Frontpage photo"
+    class="img-fluid mb-4"
+  />
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
     labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco


### PR DESCRIPTION
## Summary
- add banner image to the frontpage content
- make the sidebar fill the full viewport height

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689b2dff3260832ba492c8753797015c