### PR TITLE
Fix static image paths for logo and frontpage photo

### DIFF
--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -26,7 +26,7 @@
           <div class="sidebar-sticky pt-3">
             <div class="text-center mb-4">
               <img
-                src="{% static 'main\img\logo.svg' %}"
+                src="{% static 'main/img/logo.svg' %}"
                 alt="Vraa logo"
                 class="img-fluid"
               />

--- a/main/templates/main/frontpage.html
+++ b/main/templates/main/frontpage.html
@@ -3,7 +3,7 @@
 
 {% block content %}
   <img
-    src="main\img\House.JPEG"
+    src="{% static 'main/img/House.JPEG' %}"
     alt="Frontpage photo"
     class="img-fluid mb-4"
   />


### PR DESCRIPTION
## Summary
- Correct image path for Vraa logo in base template
- Use Django static tag for frontpage house photo

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689b362af7a4832b8eac1a53fb89c024