### PR TITLE
Use HTML email templates for registration and activation emails

### DIFF
--- a/main/templates/main/email/activation_welcome.html
+++ b/main/templates/main/email/activation_welcome.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Din konto er aktiveret</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            margin: 0;
+            padding: 0;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background: #ffffff;
+        }
+        .header {
+            background: #2C5F7C;
+            color: white;
+            padding: 30px 20px;
+            text-align: center;
+        }
+        .header h1 {
+            margin: 0;
+            font-size: 24px;
+            font-weight: 600;
+        }
+        .content {
+            padding: 30px 20px;
+            background: #ffffff;
+        }
+        .content h2 {
+            color: #2C5F7C;
+            margin-top: 0;
+            font-size: 20px;
+        }
+        .content p {
+            margin: 15px 0;
+            color: #555;
+        }
+        .message-box {
+            background: #F4E9D8;
+            border-radius: 8px;
+            padding: 15px 20px;
+            margin: 20px 0;
+            border-left: 4px solid #5FA8A0;
+        }
+        .message-box p {
+            margin: 0;
+            color: #444;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 24px;
+            background: #5FA8A0;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            font-weight: 500;
+            margin-top: 10px;
+        }
+        .footer {
+            text-align: center;
+            padding: 20px;
+            color: #888;
+            font-size: 12px;
+            background: #f9f9f9;
+            border-top: 1px solid #eee;
+        }
+        .footer a {
+            color: #5FA8A0;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Vraa Sommerhus</h1>
+        </div>
+        <div class="content">
+            <h2>Velkommen, {{ user.username }}!</h2>
+            <div class="message-box">
+                <p>Din konto er nu aktiveret. Du kan logge ind og begynde at bruge hjemmesiden.</p>
+            </div>
+            <p>På Vraa-hjemmesiden kan du:</p>
+            <ul style="color: #555; padding-left: 20px;">
+                <li>Skrive og læse beskeder på opslagstavlen</li>
+                <li>Booke ophold i sommerhuset</li>
+                <li>Se referater og vedtægter</li>
+                <li>Se familiekalenderen</li>
+            </ul>
+            <p>
+                <a href="{{ site_url }}/login/" class="button">Log ind nu</a>
+            </p>
+        </div>
+        <div class="footer">
+            <p>Du kan ændre dine notifikationsindstillinger i din <a href="{{ site_url }}/profil/rediger/">profil</a></p>
+        </div>
+    </div>
+</body>
+</html>

--- a/main/templates/main/email/registration_notification.html
+++ b/main/templates/main/email/registration_notification.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ny bruger registreret</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            margin: 0;
+            padding: 0;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background: #ffffff;
+        }
+        .header {
+            background: #2C5F7C;
+            color: white;
+            padding: 30px 20px;
+            text-align: center;
+        }
+        .header h1 {
+            margin: 0;
+            font-size: 24px;
+            font-weight: 600;
+        }
+        .header p {
+            margin: 8px 0 0;
+            font-size: 14px;
+            opacity: 0.85;
+        }
+        .content {
+            padding: 30px 20px;
+            background: #ffffff;
+        }
+        .content h2 {
+            color: #2C5F7C;
+            margin-top: 0;
+            font-size: 20px;
+        }
+        .content p {
+            margin: 15px 0;
+            color: #555;
+        }
+        .info-box {
+            background: #F4E9D8;
+            border-radius: 8px;
+            padding: 20px;
+            margin: 20px 0;
+            border-left: 4px solid #5FA8A0;
+        }
+        .info-box table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .info-box td {
+            padding: 6px 0;
+            color: #444;
+            font-size: 15px;
+        }
+        .info-box td:first-child {
+            font-weight: 600;
+            color: #2C5F7C;
+            width: 140px;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 24px;
+            background: #5FA8A0;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            font-weight: 500;
+            margin-top: 10px;
+        }
+        .footer {
+            text-align: center;
+            padding: 20px;
+            color: #888;
+            font-size: 12px;
+            background: #f9f9f9;
+            border-top: 1px solid #eee;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Vraa Sommerhus</h1>
+            <p>Administratornotifikation</p>
+        </div>
+        <div class="content">
+            <h2>Ny bruger afventer godkendelse</h2>
+            <p>En ny bruger har registreret sig på Vraa-hjemmesiden og afventer din godkendelse.</p>
+            <div class="info-box">
+                <table>
+                    <tr>
+                        <td>Brugernavn:</td>
+                        <td>{{ new_user.username }}</td>
+                    </tr>
+                    <tr>
+                        <td>E-mail:</td>
+                        <td>{{ new_user.email }}</td>
+                    </tr>
+                    <tr>
+                        <td>Tidspunkt:</td>
+                        <td>{{ registered_at }}</td>
+                    </tr>
+                </table>
+            </div>
+            <p>Log ind på hjemmesiden for at godkende eller afvise kontoen.</p>
+            <p>
+                <a href="{{ site_url }}{{ manage_url }}" class="button">Gå til brugerstyring</a>
+            </p>
+        </div>
+        <div class="footer">
+            <p>Du modtager denne e-mail fordi du er administrator på vraa.org</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/main/views.py
+++ b/main/views.py
@@ -10,6 +10,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
+from django.template.loader import render_to_string
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
@@ -124,7 +125,6 @@ class RegisterView(CreateView):
 
     def _notify_admins(self, new_user):
         """Send email notification to all admin users about a new registration."""
-        # Get all staff users with email addresses
         admin_emails = list(
             User.objects.filter(is_staff=True, is_active=True)
             .exclude(email='')
@@ -135,22 +135,34 @@ class RegisterView(CreateView):
             logger.warning('No admin email addresses configured for registration notifications')
             return
 
+        site_url = getattr(settings, 'SITE_URL', '')
         subject = f'Ny bruger registreret: {new_user.username}'
-        message = (
+        context = {
+            'new_user': new_user,
+            'registered_at': timezone.now().strftime('%d. %B %Y kl. %H:%M'),
+            'site_url': site_url,
+            'manage_url': '/brugerstyring/',
+        }
+        plain_message = (
             f'En ny bruger har registreret sig på Vraa-hjemmesiden.\n\n'
             f'Brugernavn: {new_user.username}\n'
             f'E-mail: {new_user.email}\n'
-            f'Tidspunkt: {timezone.now().strftime("%d. %B %Y kl. %H:%M")}\n\n'
-            f'Brugeren er inaktiv og afventer godkendelse.\n'
-            f'Log ind på admin-panelet for at aktivere kontoen.'
+            f'Tidspunkt: {context["registered_at"]}\n\n'
+            f'Gå til brugerstyring: {site_url}/brugerstyring/'
         )
+        try:
+            html_message = render_to_string('main/email/registration_notification.html', context)
+        except Exception as e:
+            logger.error(f'Failed to render registration notification template: {e}')
+            html_message = None
 
         try:
             send_mail(
                 subject=subject,
-                message=message,
-                from_email=settings.DEFAULT_FROM_EMAIL if hasattr(settings, 'DEFAULT_FROM_EMAIL') else None,
+                message=plain_message,
+                from_email=getattr(settings, 'DEFAULT_FROM_EMAIL', None),
                 recipient_list=admin_emails,
+                html_message=html_message,
                 fail_silently=True,
             )
             logger.info(f'Registration notification sent for user {new_user.username}')
@@ -693,17 +705,28 @@ class UserActivateView(LoginRequiredMixin, UserPassesTestMixin, View):
 
         # Send welcome email
         if user.email:
+            site_url = getattr(settings, 'SITE_URL', '')
+            plain_message = (
+                f'Hej {user.username},\n\n'
+                f'Din konto på Vraa-hjemmesiden er nu aktiveret.\n'
+                f'Du kan nu logge ind og bruge siden: {site_url}\n\n'
+                f'Venlig hilsen,\nVraa'
+            )
+            try:
+                html_message = render_to_string('main/email/activation_welcome.html', {
+                    'user': user,
+                    'site_url': site_url,
+                })
+            except Exception as e:
+                logger.error(f'Failed to render activation email template: {e}')
+                html_message = None
             try:
                 send_mail(
                     subject='Din konto er aktiveret - Vraa',
-                    message=(
-                        f'Hej {user.username},\n\n'
-                        f'Din konto på Vraa-hjemmesiden er nu aktiveret.\n'
-                        f'Du kan nu logge ind og bruge siden.\n\n'
-                        f'Venlig hilsen,\nVraa'
-                    ),
-                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    message=plain_message,
+                    from_email=getattr(settings, 'DEFAULT_FROM_EMAIL', None),
                     recipient_list=[user.email],
+                    html_message=html_message,
                     fail_silently=True,
                 )
             except Exception as e:


### PR DESCRIPTION
Replace plain-text admin registration notification and user welcome
email with styled HTML templates matching the site's existing
notification.html design (branded header, info box, CTA button).
Plain-text fallback is retained for email clients that don't render HTML.

https://claude.ai/code/session_01SBNuATZvmn7PW2VVpvFHx7