### PR TITLE
Fix weather widget and update contact info on information page

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -1733,36 +1733,77 @@ dialog::backdrop {
   margin-bottom: 1.5rem;
 }
 
-.weather-header {
+.weather-widget-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
   margin-bottom: 0.75rem;
-  font-size: 0.85rem;
-  color: var(--charcoal-soft);
 }
 
-.weather-temp {
+.weather-widget-title {
+  font-size: 0.85rem;
+  color: var(--charcoal-soft);
+  font-weight: 500;
+}
+
+.weather-widget-location {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  color: var(--charcoal);
+}
+
+.weather-widget-icon {
+  font-size: 2rem;
+}
+
+.weather-widget-temp {
   font-family: var(--font-display);
   font-size: 2.5rem;
   color: var(--charcoal);
   margin-bottom: 0.5rem;
 }
 
-.weather-details {
+.weather-widget-details {
   display: flex;
   gap: 1.5rem;
   font-size: 0.78rem;
   color: var(--charcoal-soft);
 }
 
-.weather-forecast {
+.weather-widget-detail {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.weather-widget-forecast {
   display: flex;
   gap: 1rem;
   margin-top: 0.85rem;
   padding-top: 0.85rem;
   border-top: 1px solid var(--border);
   font-size: 0.75rem;
+  color: var(--charcoal-soft);
+}
+
+.weather-forecast-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.weather-forecast-date {
+  font-weight: 500;
+  color: var(--charcoal);
+}
+
+.weather-forecast-icon {
+  font-size: 1.25rem;
+}
+
+.weather-forecast-temp {
   color: var(--charcoal-soft);
 }
 

--- a/main/templates/main/information.html
+++ b/main/templates/main/information.html
@@ -56,7 +56,7 @@
           <h3>N&oslash;gler</h3>
         </div>
         <div class="info-card-body">
-          Kontakt <strong>Troels</strong> for n&oslash;gle. N&oslash;gler til skur og Bakkens Hvile: hemmeligt?
+          Kontakt <strong>Birgitte Thue Olsen</strong> for n&oslash;gle. N&oslash;gler til skur og Bakkens Hvile: hemmeligt?
         </div>
       </div>
       <div class="info-card">
@@ -103,7 +103,7 @@
       <summary><span>&#128274;&ensp;Adgang til huset</span><span class="chevron">&#9658;</span></summary>
       <div class="details-body">
         <ul>
-          <li>N&oslash;gle: Kontakt Troels.</li>
+          <li>N&oslash;gle: Kontakt Birgitte Thue Olsen.</li>
           <li>N&oslash;gler til skur og Bakkens Hvile: hemmeligt?</li>
           <li><strong>NB: se den bl&aring; ringordner p&aring; chatollet</strong>: Her er nyttige oplysninger om huset, tlf.numre, &aring;bningstider osv.</li>
           <li>Telefon: bedes kun benyttet til korte opkald uden-&oslash;s. Lokalt: ok.</li>
@@ -113,7 +113,7 @@
     <details>
       <summary><span>&#127793;&ensp;G&aelig;ster og bes&oslash;gende</span><span class="chevron">&#9658;</span></summary>
       <div class="details-body">
-        G&aelig;ster er velkomne. Informer Troels om hvorn&aring;r du forventer g&aelig;ster. Alle g&aelig;ster skal kende husreglerne, herunder affaldsh&aring;ndtering og afrejsetjeklisten.
+        G&aelig;ster er velkomne. Informer Birgitte Thue Olsen om hvorn&aring;r du forventer g&aelig;ster. Alle g&aelig;ster skal kende husreglerne, herunder affaldsh&aring;ndtering og afrejsetjeklisten.
       </div>
     </details>
     <details>
@@ -208,7 +208,7 @@
     <details>
       <summary><span>&#128663;&ensp;K&oslash;rsel og parkering</span><span class="chevron">&#9658;</span></summary>
       <div class="details-body">
-        Information om parkering ved f&aelig;rgelejet og transport p&aring; &oslash;en. Kontakt Troels for aktuelle detaljer.
+        Information om parkering ved f&aelig;rgelejet og transport p&aring; &oslash;en. Kontakt Birgitte Thue Olsen for aktuelle detaljer.
       </div>
     </details>
   </section>
@@ -239,9 +239,9 @@
       <p>Sp&oslash;rgsm&aring;l? Skriv eller ring.</p>
     </div>
     <div class="contact-card">
-      <div class="contact-avatar">T</div>
+      <div class="contact-avatar">B</div>
       <div class="contact-info">
-        <h4>Troels</h4>
+        <h4>Birgitte Thue Olsen</h4>
         <p>N&oslash;gler, adgang og praktiske sp&oslash;rgsm&aring;l</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **Weather widget**: Fixed CSS class mismatch — the template used `weather-widget-*` classes but the stylesheet defined `weather-*` classes. Added missing styles for sub-elements (title, location, icon, detail items, forecast days) so the widget renders as a proper styled card.
- **Contact person**: Replaced all 5 occurrences of "Troels" with "Birgitte Thue Olsen" across the information page, including the contact card avatar.

> **Note**: The "Åbn afregningsskema" button still links to `#` — the file will be added in a follow-up once provided.

## Test plan
- [ ] Visit `/information/` and verify the weather widget displays with proper layout (card with temperature, wind, humidity, forecast row)
- [ ] Confirm all contact references say "Birgitte Thue Olsen" (Nøgler card, Adgang, Gæster, Kørsel, Kontakt section)
- [ ] Check responsive layout of weather widget on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)