### PR TITLE
Fix admin dashboard bugs: email link, user reject, approval feedback, button styling

### DIFF
--- a/main/services.py
+++ b/main/services.py
@@ -282,6 +282,16 @@ class AuditService:
         )
 
     @staticmethod
+    def log_user_rejected(request, username, email):
+        """Log when a pending user is rejected."""
+        AuditService.log(
+            request,
+            'user_rejected',
+            None,
+            {'username': username, 'email': email},
+        )
+
+    @staticmethod
     def log_booking_approved(request, booking):
         """Log when a booking is approved."""
         AuditService.log(

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -873,13 +873,21 @@ details[open] summary .chevron { transform: rotate(90deg); }
   text-decoration: none;
 }
 
-.btn-danger,
+.btn-danger {
+  background: var(--coral-light);
+  color: var(--coral-accent);
+  border: 1px solid var(--coral-accent);
+}
+.btn-danger:hover {
+  background: var(--coral-accent);
+  color: #fff;
+  text-decoration: none;
+}
 .btn-outline-danger {
   background: none;
   color: var(--coral-accent);
   border: 1px solid var(--coral-accent);
 }
-.btn-danger:hover,
 .btn-outline-danger:hover {
   background: var(--coral-light);
   color: var(--coral-accent);

--- a/main/templates/main/user_management.html
+++ b/main/templates/main/user_management.html
@@ -63,10 +63,14 @@
                         <td><strong>{{ user.username }}</strong></td>
                         <td>{{ user.email|default:"-" }}</td>
                         <td>{{ user.date_joined|date:"d. M Y, H:i" }}</td>
-                        <td class="text-end">
+                        <td class="text-end" style="white-space:nowrap;">
                             <form method="post" action="{% url 'main:user_activate' user.pk %}" class="d-inline">
                                 {% csrf_token %}
                                 <button type="submit" class="btn btn-sm btn-primary">Godkend</button>
+                            </form>
+                            <form method="post" action="{% url 'main:user_reject' user.pk %}" class="d-inline" onsubmit="return confirm('Er du sikker p&aring;, at du vil afvise og slette {{ user.username }}?');">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-sm btn-outline-danger">Afvis</button>
                             </form>
                         </td>
                     </tr>

--- a/main/urls.py
+++ b/main/urls.py
@@ -101,6 +101,7 @@ urlpatterns = [
     path('admin-dashboard/brugere/', views.UserManagementView.as_view(), name='user_management'),
     path('admin-dashboard/brugere/<int:pk>/aktiver/', views.UserActivateView.as_view(), name='user_activate'),
     path('admin-dashboard/brugere/<int:pk>/deaktiver/', views.UserDeactivateView.as_view(), name='user_deactivate'),
+    path('admin-dashboard/brugere/<int:pk>/afvis/', views.UserRejectView.as_view(), name='user_reject'),
     path('admin-dashboard/bookinger/', views.BookingManagementView.as_view(), name='booking_management'),
     path('admin-dashboard/bookinger/<int:pk>/godkend/', views.BookingApproveView.as_view(), name='booking_approve'),
     path('admin-dashboard/bookinger/<int:pk>/afvis/', views.BookingRejectView.as_view(), name='booking_reject'),

--- a/main/views.py
+++ b/main/views.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -141,14 +141,14 @@ class RegisterView(CreateView):
             'new_user': new_user,
             'registered_at': timezone.now().strftime('%d. %B %Y kl. %H:%M'),
             'site_url': site_url,
-            'manage_url': '/brugerstyring/',
+            'manage_url': '/admin-dashboard/brugere/',
         }
         plain_message = (
             f'En ny bruger har registreret sig på Vraa-hjemmesiden.\n\n'
             f'Brugernavn: {new_user.username}\n'
             f'E-mail: {new_user.email}\n'
             f'Tidspunkt: {context["registered_at"]}\n\n'
-            f'Gå til brugerstyring: {site_url}/brugerstyring/'
+            f'Gå til brugerstyring: {site_url}/admin-dashboard/brugere/'
         )
         try:
             html_message = render_to_string('main/email/registration_notification.html', context)
@@ -733,7 +733,7 @@ class UserActivateView(LoginRequiredMixin, UserPassesTestMixin, View):
                 logger.error(f'Failed to send activation email: {e}')
 
         messages.success(request, f'Brugeren {user.username} er nu aktiveret.')
-        return HttpResponse(status=204, headers={'HX-Trigger': 'userUpdated'})
+        return redirect('main:user_management')
 
 
 class UserDeactivateView(LoginRequiredMixin, UserPassesTestMixin, View):
@@ -746,7 +746,7 @@ class UserDeactivateView(LoginRequiredMixin, UserPassesTestMixin, View):
         user = get_object_or_404(User, pk=pk)
         if user == request.user:
             messages.error(request, 'Du kan ikke deaktivere din egen konto.')
-            return HttpResponse(status=400)
+            return redirect('main:user_management')
 
         user.is_active = False
         user.save()
@@ -755,7 +755,29 @@ class UserDeactivateView(LoginRequiredMixin, UserPassesTestMixin, View):
         AuditService.log_user_deactivated(request, user)
 
         messages.success(request, f'Brugeren {user.username} er nu deaktiveret.')
-        return HttpResponse(status=204, headers={'HX-Trigger': 'userUpdated'})
+        return redirect('main:user_management')
+
+
+class UserRejectView(LoginRequiredMixin, UserPassesTestMixin, View):
+    """Reject and delete a pending user (staff only)."""
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def post(self, request, pk):
+        user = get_object_or_404(User, pk=pk)
+        if user.is_active:
+            messages.error(request, 'Kun ventende brugere kan afvises.')
+            return redirect('main:user_management')
+
+        username = user.username
+        email = user.email
+        user.delete()
+
+        AuditService.log_user_rejected(request, username, email)
+
+        messages.success(request, f'Brugeren {username} er blevet afvist og slettet.')
+        return redirect('main:user_management')
 
 
 class AuditLogListView(LoginRequiredMixin, UserPassesTestMixin, ListView):


### PR DESCRIPTION
## Summary
- **Fix broken email link**: The "Gå til brugerstyring" button in registration notification emails linked to `/brugerstyring/` (404). Now correctly links to `/admin-dashboard/brugere/`.
- **Add reject button for pending users**: Admins can now reject (delete) pending user registrations with a confirmation dialog, not just approve them.
- **Fix page not updating after approval**: User activate/deactivate views now redirect back to the page instead of returning HTTP 204, so the page reloads and shows success/error messages.
- **Fix "Afvis" button styling**: Split `.btn-danger` (filled background) from `.btn-outline-danger` (outline only) so the booking reject button no longer appears hollow/white.

## Test plan
- [ ] Register a new user and verify the admin notification email links to `/admin-dashboard/brugere/`
- [ ] On the user management page, verify the "Afvis" button appears next to "Godkend" for pending users
- [ ] Approve a pending user and verify the page reloads with a success message
- [ ] Reject a pending user and verify the confirmation dialog appears and the user is deleted
- [ ] Check the "Afvis" button on the booking management page has a filled coral background

🤖 Generated with [Claude Code](https://claude.com/claude-code)